### PR TITLE
Remove "provide" because it's confusing replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,6 @@
         "issues": "https://github.com/sebastianbergmann/phpunit-mock-objects/issues",
         "irc": "irc://irc.freenode.net/phpunit"
     },
-    "provide": {
-        "phpunit/phpunit-mock-objects": "3.4.5"
-    },
     "replace": {
         "phpunit/phpunit-mock-objects": "3.4.4"
     },


### PR DESCRIPTION
The combination of `provide` and `replace` seems to be confusing composer. It's either causing `sminnee/phpunit-mock-objects` and `phpunit/phpunit-mock-objects` to conflict with each other, or it's causing both of them to install simultaneously.