### PR TITLE
Update sebastian/exporter constraint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ matrix:
     - php: nightly
       env:
         - COMPOSER_UPDATE_ARG="--ignore-platform-reqs"
+        - REQUIREMENTS="phpunit/phpunit:^9.3 --dev"
   
 sudo: false
 
@@ -24,6 +25,7 @@ before_install:
   - composer clear-cache
 
 install:
+  - if [ "$REQUIREMENTS" ]; then travis_retry composer require $REQUIREMENTS --no-interaction $COMPOSER_UPDATE_ARG; fi
   - travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable $COMPOSER_UPDATE_ARG
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^5.6 || ^7 || ^8",
-        "phpunit/php-text-template": "^1.2",
+        "phpunit/php-text-template": "^1.2 || ^2.0",
         "doctrine/instantiator": "^1.0.2",
         "sebastian/exporter": "^1.2 || ^2.0 || ^3 || ^4"
     },

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "php": "^5.6 || ^7 || ^8",
         "phpunit/php-text-template": "^1.2",
         "doctrine/instantiator": "^1.0.2",
-        "sebastian/exporter": "^1.2 || ^2.0 || ^3"
+        "sebastian/exporter": "^1.2 || ^2.0 || ^3 || ^4"
     },
     "require-dev": {
         "sminnee/phpunit": "^5.7.29"


### PR DESCRIPTION
This allows sebastian/exporter v4 installs on PHPUnit `^9.3`. This is currently one deep trickle down constraint that blocks PHP 8 support in Laravel Dusk.

Dusk -> PHP Webdriver -> PHPUnit Mock Objects

Would appreciate a quick tag for this if possible! Thanks :)