### PR TITLE
FIX Ensure constructors are populated in mocks of interfaces in PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-    - php: 7.0
-    - php: 7.1
-    - php: 7.2
     - php: 7.3
     - php: 7.4
     - php: nightly
@@ -28,6 +24,8 @@ install:
   - travis_retry composer update --no-interaction --no-ansi --no-progress --no-suggest --optimize-autoloader --prefer-stable $COMPOSER_UPDATE_ARG
 
 script:
+  - cat ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - php -i | grep xdebug
   - ./vendor/bin/phpunit --coverage-clover=coverage.xml
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: php
 env:
   global:
     - COMPOSER_ROOT_VERSION=3.4.x-dev
+    - XDEBUG_MODE=coverage # Required for Xdebug 3
 
 matrix:
   fast_finish: true

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
         "sebastian/exporter": "^1.2 || ^2.0 || ^3"
     },
     "require-dev": {
-        "sminnee/phpunit": "^5.7.29"
+        "sminnee/phpunit": "^5.7.29",
+        "phpunit/php-token-stream": "4.0.4 as 2.0.2"
     },
     "conflict": {
         "phpunit/phpunit": "<5.4.0"

--- a/src/Framework/MockObject/Generator.php
+++ b/src/Framework/MockObject/Generator.php
@@ -819,7 +819,7 @@ class PHPUnit_Framework_MockObject_Generator
                 try {
                     $method = $class->getMethod($methodName);
 
-                    if ($this->canMockMethod($method)) {
+                    if ($this->canMockMethod($method, $isInterface)) {
                         $mockedMethods .= $this->generateMockedMethodDefinitionFromExisting(
                             $templateDir,
                             $method,
@@ -838,7 +838,7 @@ class PHPUnit_Framework_MockObject_Generator
             }
         } elseif ($isMultipleInterfaces) {
             foreach ($methods as $methodName) {
-                if ($this->canMockMethod($methodReflections[$methodName])) {
+                if ($this->canMockMethod($methodReflections[$methodName], true)) {
                     $mockedMethods .= $this->generateMockedMethodDefinitionFromExisting(
                         $templateDir,
                         $methodReflections[$methodName],
@@ -1118,9 +1118,11 @@ class PHPUnit_Framework_MockObject_Generator
      *
      * @return bool
      */
-    private function canMockMethod(ReflectionMethod $method)
+    private function canMockMethod(ReflectionMethod $method, $isInterface)
     {
-        if ($method->isConstructor() ||
+        // PHP 8 reports constructors in interfaces 'accurately', producing broken mocks
+        // Fixed upstream at https://github.com/sebastianbergmann/phpunit/commit/9fb2cb4e803aecdeca3333b5aff1913d837b3880
+        if ($method->isConstructor() && !$isInterface ||
             $method->isFinal() ||
             $method->isPrivate() ||
             $this->isMethodNameBlacklisted($method->getName())) {

--- a/tests/MockObject/Generator/interface_with_constructor.phpt
+++ b/tests/MockObject/Generator/interface_with_constructor.phpt
@@ -1,0 +1,97 @@
+--TEST--
+PHPUnit_Framework_MockObject_Generator::generate('FooWithConstructor', array(), 'MockFooWithConstructor', true, true)
+--FILE--
+<?php
+interface FooWithConstructor
+{
+    public function __construct();
+}
+
+require __DIR__ . '/../../../vendor/autoload.php';
+
+$generator = new PHPUnit_Framework_MockObject_Generator;
+
+$mock = $generator->generate(
+    'FooWithConstructor',
+    array(),
+    'MockFooWithConstructor',
+    true,
+    true
+);
+
+print $mock['code'];
+?>
+--EXPECTF--
+class MockFooWithConstructor implements PHPUnit_Framework_MockObject_MockObject, FooWithConstructor
+{
+    private $__phpunit_invocationMocker;
+    private $__phpunit_originalObject;
+    private $__phpunit_configurable = [];
+
+    public function __clone()
+    {
+        $this->__phpunit_invocationMocker = clone $this->__phpunit_getInvocationMocker();
+    }
+
+    public function __construct()
+    {
+        $arguments = array();
+        $count     = func_num_args();
+
+        if ($count > 0) {
+            $_arguments = func_get_args();
+
+            for ($i = 0; $i < $count; $i++) {
+                $arguments[] = $_arguments[$i];
+            }
+        }
+
+        $result = $this->__phpunit_getInvocationMocker()->invoke(
+            new PHPUnit_Framework_MockObject_Invocation_Object(
+                'FooWithConstructor', '__construct', $arguments, '', $this, true
+            )
+        );
+
+        return $result;
+    }
+
+    public function expects(PHPUnit_Framework_MockObject_Matcher_Invocation $matcher)
+    {
+        return $this->__phpunit_getInvocationMocker()->expects($matcher);
+    }
+
+    public function method()
+    {
+        $any = new PHPUnit_Framework_MockObject_Matcher_AnyInvokedCount;
+        $expects = $this->expects($any);
+        return call_user_func_array(array($expects, 'method'), func_get_args());
+    }
+
+    public function __phpunit_setOriginalObject($originalObject)
+    {
+        $this->__phpunit_originalObject = $originalObject;
+    }
+
+    public function __phpunit_getInvocationMocker()
+    {
+        if ($this->__phpunit_invocationMocker === null) {
+            $this->__phpunit_invocationMocker = new PHPUnit_Framework_MockObject_InvocationMocker($this->__phpunit_configurable);
+        }
+
+        return $this->__phpunit_invocationMocker;
+    }
+
+    public function __phpunit_hasMatchers()
+    {
+        return $this->__phpunit_getInvocationMocker()->hasMatchers();
+    }
+
+    public function __phpunit_verify($unsetInvocationMocker = true)
+    {
+        $this->__phpunit_getInvocationMocker()->verify();
+
+        if ($unsetInvocationMocker) {
+            $this->__phpunit_invocationMocker = null;
+        }
+    }
+}


### PR DESCRIPTION
See https://news-web.php.net/php.internals/109377

This is a legitimate issue caused by a change in PHP's behaviour, and was fixed upstream in PHPUnit 9, so it makes sense to implement the same patch here.

Fixes #7.